### PR TITLE
fix: signupした後にsigninするときのバグを修正

### DIFF
--- a/backend/src/main/kotlin/com/example/backend/controller/SecurityController.kt
+++ b/backend/src/main/kotlin/com/example/backend/controller/SecurityController.kt
@@ -30,7 +30,7 @@ class SecurityController(
         @RequestParam("password") password: String
     ): String {
         userDetailsManager.createUser(makeUser(username, password, "USER"))
-        return "redirect: /"
+        return "redirect:/"
     }
 
     private fun makeUser(user: String, pw: String, role: String): UserDetails {


### PR DESCRIPTION
signupした後にsigninすると404ページが表示されるが、リロードするとsigninできるバグを修正